### PR TITLE
Reordered WalpapperPosition-Parsing

### DIFF
--- a/source/SylphyHorn/Services/WallpaperService.cs
+++ b/source/SylphyHorn/Services/WallpaperService.cs
@@ -166,10 +166,10 @@ namespace SylphyHorn.Services
 			var options2 = options.ToLower();
 			if (options2[0] == 'c') return WallpaperPosition.Center;
 			if (options2[0] == 't') return WallpaperPosition.Tile;
-			if (options2[0] == 's') return WallpaperPosition.Stretch;
-			if (options2[0] == 'f') return WallpaperPosition.Fit;
-			if (options2.StartsWith("fil")) return WallpaperPosition.Fill;
 			if (options2.StartsWith("sp")) return WallpaperPosition.Span;
+			if (options2[0] == 's') return WallpaperPosition.Stretch;
+			if (options2.StartsWith("fil")) return WallpaperPosition.Fill;
+			if (options2[0] == 'f') return WallpaperPosition.Fit;			
 			return WallpaperPosition.Fit;
 		}
 	}


### PR DESCRIPTION
Moved .StartsWith("sp") pior to [0] == 's' and .StartsWith("fil") prior to [0] == 'f', otherwise Span and Fill never get hit.